### PR TITLE
fix(QuickLoopService): handle locked quick loop state in getUpdatedPropsByClearingMarker (r26.03)

### DIFF
--- a/packages/job-worker/src/playout/model/services/QuickLoopService.ts
+++ b/packages/job-worker/src/playout/model/services/QuickLoopService.ts
@@ -142,7 +142,13 @@ export class QuickLoopService {
 	}
 
 	getUpdatedPropsByClearingMarkers(): QuickLoopProps | undefined {
-		if (!this.playoutModel.playlist.quickLoop || this.playoutModel.playlist.quickLoop.locked) return undefined
+		if (!this.playoutModel.playlist.quickLoop) return undefined
+
+		if (this.playoutModel.playlist.quickLoop.locked) {
+			const quickLoopProps = clone(this.playoutModel.playlist.quickLoop)
+			quickLoopProps.running = false
+			return quickLoopProps
+		}
 
 		const quickLoopProps = clone(this.playoutModel.playlist.quickLoop)
 		delete quickLoopProps.start

--- a/packages/webui/src/client/lib/rundownTiming.ts
+++ b/packages/webui/src/client/lib/rundownTiming.ts
@@ -135,6 +135,8 @@ export class RundownTimingCalculator {
 		let lastSegmentIds: { segmentId: SegmentId; segmentPlayoutId: SegmentPlayoutId } | undefined = undefined
 		let nextRundownAnchor: number | undefined = undefined
 
+		const entirePlaylistIsLooping = isEntirePlaylistLooping(playlist)
+
 		if (playlist) {
 			const breakProps = currentRundown ? this.getRundownsBeforeNextBreak(rundowns, currentRundown) : undefined
 
@@ -499,7 +501,7 @@ export class RundownTimingCalculator {
 					// this is a line before next line
 					localAccum = this.linearParts[i][1] || 0
 					// only null the values if not looping, if looping, these will be offset by the countdown for the last part
-					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) {
+					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])] && !entirePlaylistIsLooping) {
 						this.linearParts[i][1] = null // we use null to express 'will not probably be played out, if played in order'
 					}
 				} else if (i === currentAIndex) {
@@ -531,7 +533,7 @@ export class RundownTimingCalculator {
 					// this away from this line.
 					this.linearParts[i][1] = (this.linearParts[i][1] || 0) - localAccum + currentRemaining
 
-					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) {
+					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])] && !entirePlaylistIsLooping) {
 						timeTillEndLoop = timeTillEndLoop ?? this.linearParts[i][1] ?? undefined
 					}
 
@@ -553,7 +555,7 @@ export class RundownTimingCalculator {
 				// if timeTillEndLoop was undefined then we can assume the end of the loop is the last line in the rundown
 				timeTillEndLoop = timeTillEndLoop ?? waitAccumulator - localAccum + currentRemaining
 				for (let i = 0; i < nextAIndex; i++) {
-					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])]) continue
+					if (!partsInQuickLoop[unprotectString(this.linearParts[i][0])] && !entirePlaylistIsLooping) continue
 
 					// this countdown is the wait until the loop ends + whatever waits occur before this part but inside the loop
 					this.linearParts[i][1] = timeTillEndLoop + waitInLoop

--- a/packages/webui/src/client/ui/SegmentList/LinePart.tsx
+++ b/packages/webui/src/client/ui/SegmentList/LinePart.tsx
@@ -29,6 +29,7 @@ interface IProps {
 	isQuickLoopEnd: boolean
 	// isLastSegment?: boolean
 	// isLastPartInSegment?: boolean
+	isEntirePlaylistLooping: boolean
 	isPlaylistLooping: boolean
 	indicatorColumns: Record<string, ISourceLayerExtended[]>
 	adLibIndicatorColumns: Record<string, ISourceLayerExtended[]>
@@ -55,6 +56,7 @@ export function LinePart({
 	indicatorColumns,
 	adLibIndicatorColumns,
 	isPlaylistLooping,
+	isEntirePlaylistLooping,
 	isQuickLoopStart,
 	isQuickLoopEnd,
 	onContextMenu,
@@ -78,7 +80,8 @@ export function LinePart({
 
 	const timingId = getPartInstanceTimingId(part.instance)
 	const isInsideQuickLoop = (timingDurations.partsInQuickLoop || {})[timingId]
-	const isOutsideActiveQuickLoop = isPlaylistLooping && !isInsideQuickLoop && !isNextPart && !hasAlreadyPlayed
+	const isOutsideActiveQuickLoop =
+		isPlaylistLooping && !isInsideQuickLoop && !isEntirePlaylistLooping && !isNextPart && !hasAlreadyPlayed
 
 	const getPartContext = useCallback(() => {
 		const partElement = document.querySelector('#' + SegmentTimelinePartElementId + part.instance._id)

--- a/packages/webui/src/client/ui/SegmentList/SegmentList.tsx
+++ b/packages/webui/src/client/ui/SegmentList/SegmentList.tsx
@@ -134,6 +134,9 @@ const SegmentListInner = React.forwardRef<HTMLDivElement, IProps>(function Segme
 		// if (isLivePart) currentPartIndex = index
 		// if (isNextPart) nextPartIndex = index
 
+		const isPlaylistLooping = RundownResolver.isLoopRunning(props.playlist)
+		const isEntirePlaylistLooping = RundownResolver.isEntirePlaylistLooping(props.playlist)
+
 		if (part.instance.part.invalid && part.instance.part.gap) return null
 
 		const partComponent = (
@@ -156,7 +159,8 @@ const SegmentListInner = React.forwardRef<HTMLDivElement, IProps>(function Segme
 				doesPlaylistHaveNextPart={playlistHasNextPart}
 				onPieceDoubleClick={props.onPieceDoubleClick}
 				onContextMenu={props.onContextMenu}
-				isPlaylistLooping={RundownResolver.isLoopRunning(props.playlist)}
+				isPlaylistLooping={isPlaylistLooping}
+				isEntirePlaylistLooping={isEntirePlaylistLooping}
 				isQuickLoopStart={RundownResolver.isQuickLoopStart(part.partId, props.playlist)}
 				isQuickLoopEnd={RundownResolver.isQuickLoopEnd(part.partId, props.playlist)}
 			/>

--- a/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/SegmentStoryboard.tsx
@@ -206,7 +206,8 @@ export const SegmentStoryboard = React.memo(
 			squishedPartsNum > 1 ? Math.max(4, (spaceLeft - PART_WIDTH) / (squishedPartsNum - 1)) : null
 
 		const playlistHasNextPart = !!props.playlist.nextPartInfo
-		const playlistIsLooping = RundownResolver.isLoopRunning(props.playlist)
+		const isPlaylistLooping = RundownResolver.isLoopRunning(props.playlist)
+		const isEntirePlaylistLooping = RundownResolver.isEntirePlaylistLooping(props.playlist)
 
 		renderedParts.forEach((part, index) => {
 			const isLivePart = part.instance._id === props.playlist.currentPartInfo?.partInstanceId
@@ -235,7 +236,8 @@ export const SegmentStoryboard = React.memo(
 					)}
 					isQuickLoopStart={RundownResolver.isQuickLoopStart(part.partId, props.playlist)}
 					isQuickLoopEnd={RundownResolver.isQuickLoopEnd(part.partId, props.playlist)}
-					isPlaylistLooping={playlistIsLooping}
+					isPlaylistLooping={isPlaylistLooping}
+					isEntirePlaylistLooping={isEntirePlaylistLooping}
 					doesPlaylistHaveNextPart={playlistHasNextPart}
 					displayLiveLineCounter={props.displayLiveLineCounter}
 					inHold={!!(props.playlist.holdState && props.playlist.holdState !== RundownHoldState.COMPLETE)}

--- a/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
+++ b/packages/webui/src/client/ui/SegmentStoryboard/StoryboardPart.tsx
@@ -34,6 +34,7 @@ interface IProps {
 	isLastSegment?: boolean
 	isLastPartInSegment?: boolean
 	isPlaylistLooping?: boolean
+	isEntirePlaylistLooping?: boolean
 	isEndOfLoopingShow?: boolean
 	isQuickLoopStart: boolean
 	isQuickLoopEnd: boolean
@@ -56,6 +57,7 @@ export function StoryboardPart({
 	isLastPartInSegment,
 	isLastSegment,
 	isPlaylistLooping,
+	isEntirePlaylistLooping,
 	isEndOfLoopingShow,
 	isQuickLoopStart,
 	isQuickLoopEnd,
@@ -127,7 +129,7 @@ export function StoryboardPart({
 	const isInvalid = part.instance.part.invalid
 	const isFloated = part.instance.part.floated
 	const isInsideQuickLoop = timingDurations.partsInQuickLoop?.[getPartInstanceTimingId(part.instance)] ?? false
-	const isOutsideActiveQuickLoop = !isInsideQuickLoop && isPlaylistLooping && !isNextPart
+	const isOutsideActiveQuickLoop = !isInsideQuickLoop && isPlaylistLooping && !isEntirePlaylistLooping && !isNextPart
 
 	return (
 		<ContextMenuTrigger

--- a/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
+++ b/packages/webui/src/client/ui/SegmentTimeline/Parts/SegmentTimelinePart.tsx
@@ -686,7 +686,10 @@ export class SegmentTimelinePartClass extends React.Component<Translated<WithTim
 		}
 
 		const isOutsideActiveQuickLoop =
-			!this.state.isInQuickLoop && RundownResolver.isLoopRunning(this.props.playlist) && !this.state.isNext
+			!this.state.isInQuickLoop &&
+			RundownResolver.isLoopRunning(this.props.playlist) &&
+			!RundownResolver.isEntirePlaylistLooping(this.props.playlist) &&
+			!this.state.isNext
 		const isQuickLoopStart = RundownResolver.isQuickLoopStart(this.props.part.partId, this.props.playlist)
 		const isQuickLoopEnd = RundownResolver.isQuickLoopEnd(this.props.part.partId, this.props.playlist)
 


### PR DESCRIPTION
This is a cherry-pick of https://github.com/nrkno/sofie-nrk-core/pull/24 for Sofie 26.03
